### PR TITLE
chore: update js-yaml

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
   },
   "dependencies": {
     "case": "^1.6.3",
-    "js-yaml": "^4.1.0",
+    "js-yaml": "^4.1.1",
     "lodash.merge": "^4.6.2",
     "projen": "^0.88.2"
   },

--- a/package.json
+++ b/package.json
@@ -69,8 +69,7 @@
   "dependencies": {
     "case": "^1.6.3",
     "js-yaml": "^4.1.1",
-    "lodash.merge": "^4.6.2",
-    "projen": "^0.88.2"
+    "lodash.merge": "^4.6.2"
   },
   "bundledDependencies": [
     "case",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3812,6 +3812,13 @@ js-yaml@^4.1.0:
   dependencies:
     argparse "^2.0.1"
 
+js-yaml@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.1.tgz#854c292467705b699476e1a2decc0c8a3458806b"
+  integrity sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==
+  dependencies:
+    argparse "^2.0.1"
+
 jsdom@^25.0.0:
   version "25.0.1"
   resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-25.0.1.tgz#536ec685c288fc8a5773a65f82d8b44badcc73ef"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3948,7 +3948,7 @@ js-yaml@^4.1.1:
   dependencies:
     argparse "^2.0.1"
 
-jsdom@^25.0.0:
+jsdom@^25.0.1:
   version "25.0.1"
   resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-25.0.1.tgz#536ec685c288fc8a5773a65f82d8b44badcc73ef"
   integrity sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==


### PR DESCRIPTION
Update to js-yaml to fix a security issue.

For more info see:
https://github.com/nodeca/js-yaml/security/advisories/GHSA-mh29-5h37-fv8m
